### PR TITLE
Fix basename detection and record exit status

### DIFF
--- a/core/src/trace.rs
+++ b/core/src/trace.rs
@@ -221,7 +221,9 @@ impl Visit for ScenarioEventVisitor {
 
     fn record_i64(&mut self, field: &Field, _value: i64) {
         match field.name() {
-            "remote_sudo.exit_status" => {}
+            "remote_sudo.exit_status" => {
+                self.remote_sudo_exit_status = Some(_value);
+            }
             _ => {
                 error!("Unrecognized field: {}", field.name());
             }


### PR DESCRIPTION
## Summary
- add more robust basename detection for path variables
- test file path without extension
- record remote command exit status in the tracing visitor

## Testing
- `cargo test -p scenario-rs-core --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68416f1b64c0832093c9828a7c9269a8