### PR TITLE
Handle Windows directory suffixes for required path variables

### DIFF
--- a/core/src/scenario/on_fail_steps.rs
+++ b/core/src/scenario/on_fail_steps.rs
@@ -63,8 +63,8 @@ use tracing::{debug, instrument};
 /// // Create empty on_fail_steps and add tasks manually
 /// let mut on_fail_steps = OnFailSteps::default();
 /// for (idx, name) in task_names.iter().enumerate() {
-///     if let Some(task) = tasks.get(&name) {
-///        let on_fail_step = OnFailStep::from((idx, task));
+///     if let Some(task) = tasks.get(name).cloned() {
+///         let on_fail_step = OnFailStep::from((idx, task));
 ///         on_fail_steps.push(on_fail_step);
 ///     }
 /// }

--- a/core/src/scenario/step.rs
+++ b/core/src/scenario/step.rs
@@ -76,7 +76,7 @@ use tracing::{debug, instrument};
 ///
 /// // Create on_fail steps manually using the public API
 /// let mut on_fail_steps = OnFailSteps::default();
-/// if let Some(cleanup_task) = tasks.get("cleanup") {
+/// if let Some(cleanup_task) = tasks.get("cleanup").cloned() {
 ///     let on_fail_step = OnFailStep::from((0, cleanup_task));
 ///     on_fail_steps.push(on_fail_step);
 /// }

--- a/core/src/scenario/variables/required.rs
+++ b/core/src/scenario/variables/required.rs
@@ -160,13 +160,7 @@ impl RequiredVariables {
                 if let VariableType::Path = required_variable.var_type() {
                     let path = PathBuf::from(&value);
 
-                    let is_dir_path = value
-                        .trim_end()
-                        .chars()
-                        .rev()
-                        .find(|c| !c.is_whitespace())
-                        .map(|c| c == '\\' || std::path::is_separator(c))
-                        .unwrap_or(false);
+                    let is_dir_path = ends_with_directory_separator(&value);
 
                     if !is_dir_path && (path.is_file() || path.extension().is_some()) {
                         if let Some(file_name_str) = path.file_name().and_then(|s| s.to_str()) {
@@ -192,6 +186,16 @@ impl RequiredVariables {
             self.insert(key, var);
         }
     }
+}
+
+fn ends_with_directory_separator(value: &str) -> bool {
+    value
+        .trim_end()
+        .chars()
+        .rev()
+        .next()
+        .map(|c| c == '\\' || std::path::is_separator(c))
+        .unwrap_or(false)
 }
 
 /// Represents a single required variable with its metadata and value.

--- a/core/src/scenario/variables/required.rs
+++ b/core/src/scenario/variables/required.rs
@@ -159,7 +159,16 @@ impl RequiredVariables {
 
                 if let VariableType::Path = required_variable.var_type() {
                     let path = PathBuf::from(&value);
-                    if path.is_file() || path.extension().is_some() {
+
+                    let is_dir_path = value
+                        .trim_end()
+                        .chars()
+                        .rev()
+                        .find(|c| !c.is_whitespace())
+                        .map(|c| c == '\\' || std::path::is_separator(c))
+                        .unwrap_or(false);
+
+                    if !is_dir_path && (path.is_file() || path.extension().is_some()) {
                         if let Some(file_name_str) = path.file_name().and_then(|s| s.to_str()) {
                             let basename_key = format!("basename:{}", name);
                             let label = format!("Basename of {}", required_variable.label());
@@ -602,6 +611,46 @@ mod tests {
         assert_eq!(vars.len(), 1); // No basename was added
         assert_eq!(vars.get("path_var").unwrap().value(), "/tmp/directory/");
         assert!(!vars.contains_key("basename:path_var"));
+    }
+
+    #[test]
+    fn test_upsert_with_windows_style_directory_terminators() {
+        // Given
+        let mut vars = RequiredVariables::default();
+        vars.insert(
+            "windows_dir".to_string(),
+            RequiredVariable {
+                label: "Windows Directory".to_string(),
+                var_type: VariableType::Path,
+                value: "".to_string(),
+                read_only: false,
+            },
+        );
+        vars.insert(
+            "windows_dir_alt".to_string(),
+            RequiredVariable {
+                label: "Windows Directory Alt".to_string(),
+                var_type: VariableType::Path,
+                value: "".to_string(),
+                read_only: false,
+            },
+        );
+
+        let windows_dir_value = "C\\Temp\\";
+        let windows_dir_alt_value = "C\\Temp/";
+
+        let mut update_map = HashMap::new();
+        update_map.insert("windows_dir".to_string(), windows_dir_value.to_string());
+        update_map.insert("windows_dir_alt".to_string(), windows_dir_alt_value.to_string());
+
+        // When
+        vars.upsert(update_map);
+
+        // Then
+        assert_eq!(vars.get("windows_dir").unwrap().value(), windows_dir_value);
+        assert_eq!(vars.get("windows_dir_alt").unwrap().value(), windows_dir_alt_value);
+        assert!(!vars.contains_key("basename:windows_dir"));
+        assert!(!vars.contains_key("basename:windows_dir_alt"));
     }
 
     #[test]

--- a/core/src/trace.rs
+++ b/core/src/trace.rs
@@ -219,9 +219,11 @@ impl Visit for ScenarioEventVisitor {
         }
     }
 
-    fn record_i64(&mut self, field: &Field, _value: i64) {
+    fn record_i64(&mut self, field: &Field, value: i64) {
         match field.name() {
-            "remote_sudo.exit_status" => {}
+            "remote_sudo.exit_status" => {
+                self.remote_sudo_exit_status = Some(value);
+            }
             _ => {
                 error!("Unrecognized field: {}", field.name());
             }


### PR DESCRIPTION
## Summary
- ensure `RequiredVariables::upsert` skips basename variables for paths ending in either `/` or `\`
- cover Windows-style directory terminators in required variable tests
- persist remote sudo exit status in the trace visitor and fix doc examples that compile against owned tasks

## Testing
- cargo test -p scenario-rs-core

------
https://chatgpt.com/codex/tasks/task_e_68dd822a85148320aff6ebef2f5efb75